### PR TITLE
[Dinkur CLI] Ask user when formerly AFK

### DIFF
--- a/cmd/in.go
+++ b/cmd/in.go
@@ -60,31 +60,7 @@ func init() {
 			if err != nil {
 				console.PrintFatal("Error starting task:", err)
 			}
-			var toPrint []console.LabelledTask
-			if startedTask.Previous != nil {
-				toPrint = append(toPrint, console.LabelledTask{
-					Label: "Stopped task:",
-					Task:  *startedTask.Previous,
-				})
-			}
-			noActive := false
-			if startedTask.New.End != nil {
-				toPrint = append(toPrint, console.LabelledTask{
-					Label: "Added task:",
-					Task:  startedTask.New,
-				})
-				noActive = true
-			} else {
-				toPrint = append(toPrint, console.LabelledTask{
-					Label:      "Started task:",
-					Task:       startedTask.New,
-					NoDuration: true,
-				})
-			}
-			console.PrintTaskLabelSlice(toPrint)
-			if noActive {
-				fmt.Println("You have no active task.")
-			}
+			printStartedTask(startedTask)
 		},
 	}
 	RootCmd.AddCommand(inCmd)
@@ -96,4 +72,32 @@ func init() {
 	inCmd.Flags().BoolVarP(&flagAfterLast, "after-last", "L", false, `sets --start time to the end time of latest task`)
 	inCmd.Flags().UintVarP(&flagBeforeID, "before-id", "b", 0, `sets --end time to the start time of task with ID`)
 	inCmd.RegisterFlagCompletionFunc("before-id", taskIDComplete)
+}
+
+func printStartedTask(startedTask dinkur.StartedTask) {
+	var toPrint []console.LabelledTask
+	if startedTask.Previous != nil {
+		toPrint = append(toPrint, console.LabelledTask{
+			Label: "Stopped task:",
+			Task:  *startedTask.Previous,
+		})
+	}
+	noActive := false
+	if startedTask.New.End != nil {
+		toPrint = append(toPrint, console.LabelledTask{
+			Label: "Added task:",
+			Task:  startedTask.New,
+		})
+		noActive = true
+	} else {
+		toPrint = append(toPrint, console.LabelledTask{
+			Label:      "Started task:",
+			Task:       startedTask.New,
+			NoDuration: true,
+		})
+	}
+	console.PrintTaskLabelSlice(toPrint)
+	if noActive {
+		fmt.Println("You have no active task.")
+	}
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -75,22 +75,6 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 `, RootCmd.Name()),
 		Run: func(cmd *cobra.Command, args []string) {
 			connectClientOrExit()
-			activeTask, err := c.ActiveTask(context.Background())
-			if err == nil && activeTask != nil {
-				res, err := console.PromptAFKResolution(dinkur.AlertFormerlyAFK{
-					AFKSince:   time.Now().Add(-15 * time.Minute),
-					ActiveTask: *activeTask,
-				})
-				if err != nil {
-					console.PrintFatal("Prompt error:", err)
-				}
-				fmt.Println()
-				fmt.Println("Resolution:")
-				enc := json.NewEncoder(os.Stdout)
-				enc.SetIndent("", "  ")
-				enc.Encode(res)
-				os.Exit(1)
-			}
 			rand.Seed(time.Now().UnixMicro())
 			search := dinkur.SearchTask{
 				Limit:     flagLimit,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -75,6 +75,22 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 `, RootCmd.Name()),
 		Run: func(cmd *cobra.Command, args []string) {
 			connectClientOrExit()
+			activeTask, err := c.ActiveTask(context.Background())
+			if err == nil && activeTask != nil {
+				res, err := console.PromptAFKResolution(dinkur.AlertFormerlyAFK{
+					AFKSince:   time.Now().Add(-15 * time.Minute),
+					ActiveTask: *activeTask,
+				})
+				if err != nil {
+					console.PrintFatal("Prompt error:", err)
+				}
+				fmt.Println()
+				fmt.Println("Resolution:")
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				enc.Encode(res)
+				os.Exit(1)
+			}
 			rand.Seed(time.Now().UnixMicro())
 			search := dinkur.SearchTask{
 				Limit:     flagLimit,
@@ -102,7 +118,7 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 				if len(args) == 0 {
 					searchStart, searchEnd = "", ""
 				}
-				console.PrintTaskList(tasks, searchStart, searchEnd)
+				console.PrintTaskListSearched(tasks, searchStart, searchEnd)
 			case "json":
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -23,7 +23,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/dinkur/dinkur/internal/console"
@@ -54,13 +53,9 @@ Warning: Removing a task cannot be undone!`,
 				if err != nil {
 					console.PrintFatal("Error getting task:", err)
 				}
-				ok, err := console.PromptTaskRemoval(task)
+				err = console.PromptTaskRemoval(task)
 				if err != nil {
 					console.PrintFatal("Prompt error:", err)
-				}
-				if !ok {
-					fmt.Println("Aborted by user.")
-					os.Exit(1)
 				}
 			}
 			removedTask, err := c.DeleteTask(context.Background(), flagID)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -201,6 +201,7 @@ func checkAlerts(c dinkur.Client) {
 
 func promptAFKResolution(c dinkur.Client, alert dinkur.Alert, formerlyAFK dinkur.AlertFormerlyAFK) {
 	res, err := console.PromptAFKResolution(formerlyAFK)
+	fmt.Println()
 	if err != nil {
 		console.PrintFatal("Prompt error:", err)
 	}
@@ -223,6 +224,8 @@ func promptAFKResolution(c dinkur.Client, alert dinkur.Alert, formerlyAFK dinkur
 	if _, err := c.DeleteAlert(context.Background(), alert.ID); err != nil {
 		console.PrintFatal("Error removing alert:", err)
 	}
+	fmt.Println("Continuing with command...")
+	fmt.Println()
 }
 
 func connectToDBClient(skipMigrate bool) (dinkur.Client, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -183,11 +183,11 @@ func connectToGRPCClient() (dinkur.Client, error) {
 	if err := c.Ping(context.Background()); err != nil {
 		return nil, fmt.Errorf("attempting ping: %w", err)
 	}
-	checkAlerts()
+	checkAlerts(c)
 	return c, nil
 }
 
-func checkAlerts() {
+func checkAlerts(c dinkur.Client) {
 	alerts, err := c.GetAlertList(context.Background())
 	if err != nil {
 		console.PrintFatal("Error getting alerts list:", err)

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/dinkur/dinkur/pkg/dinkur"
 	"github.com/fatih/color"
@@ -50,8 +49,8 @@ var (
 	taskStartColor           = color.New(color.FgGreen)
 	taskEndColor             = color.New(color.FgGreen)
 	taskEndNilColor          = color.New(color.FgHiBlack, color.Italic)
-	taskEndNilText           = "active…"
-	taskEndNilTextLen        = utf8.RuneCountInString(taskEndNilText)
+	taskEndNilTextNow        = "now…"
+	taskEndNilTextActive     = "active…"
 	taskDurationColor        = color.New(color.FgCyan)
 	taskEditDelimColor       = color.New(color.FgHiMagenta)
 	taskEditNoneColor        = color.New(color.FgHiBlack, color.Italic)
@@ -75,6 +74,7 @@ var (
 
 	promptWarnIconColor = color.New(color.FgHiRed, color.Bold)
 	promptWarnIconText  = "!"
+	promptErrorColor    = color.New(color.FgRed)
 )
 
 // LabelledTask holds a string label and a task. Used when printing multiple
@@ -167,7 +167,13 @@ func PrintTaskEdit(update dinkur.UpdatedTask) {
 
 // PrintTaskList writes a table for a list of tasks, grouped by the date
 // (year, month, day), to STDOUT.
-func PrintTaskList(tasks []dinkur.Task, searchStart, searchEnd string) {
+func PrintTaskList(tasks []dinkur.Task) {
+	PrintTaskListSearched(tasks, "", "")
+}
+
+// PrintTaskListSearched writes a table for a list of tasks, grouped by the date
+// (year, month, day), to STDOUT, as well as highlighting search terms (if any).
+func PrintTaskListSearched(tasks []dinkur.Task, searchStart, searchEnd string) {
 	if len(tasks) == 0 {
 		tableEmptyColor.Fprintln(stdout, tableEmptyText)
 		return
@@ -208,7 +214,7 @@ func PrintTaskList(tasks []dinkur.Task, searchStart, searchEnd string) {
 	}
 	sum := sumTasks(tasks)
 	t.CommitRow() // commit empty delimiting row
-	endStr := taskEndNilText
+	endStr := taskEndNilTextActive
 	if sum.end != nil {
 		endStr = sum.end.Format(timeFormatShort)
 	}

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -55,9 +55,10 @@ var (
 	taskEditDelimColor       = color.New(color.FgHiMagenta)
 	taskEditNoneColor        = color.New(color.FgHiBlack, color.Italic)
 
-	taskEditPrefix  = "  "
-	taskEditSpacing = "   "
-	taskEditDelim   = "=>"
+	taskEditPrefix   = "  "
+	taskEditNoChange = "No changes were applied."
+	taskEditSpacing  = "   "
+	taskEditDelim    = "=>"
 
 	fatalLabelColor = color.New(color.FgHiRed, color.Bold)
 	fatalValueColor = color.New(color.FgRed)
@@ -72,9 +73,10 @@ var (
 	usageHeaderColor = color.New(color.FgYellow, color.Underline, color.Italic)
 	usageHelpColor   = color.New(color.FgHiBlack, color.Italic)
 
-	promptWarnIconColor = color.New(color.FgHiRed, color.Bold)
-	promptWarnIconText  = "!"
-	promptErrorColor    = color.New(color.FgRed)
+	promptWarnIconColor  = color.New(color.FgHiRed, color.Bold)
+	promptWarnIconText   = "!"
+	promptErrorColor     = color.New(color.FgRed)
+	promptCtrlCHelpColor = color.New(color.FgHiBlack, color.Italic)
 )
 
 // LabelledTask holds a string label and a task. Used when printing multiple
@@ -158,7 +160,7 @@ func PrintTaskEdit(update dinkur.UpdatedTask) {
 		t.CommitRow()
 	}
 	if t.Rows() == 0 {
-		taskEditNoneColor.Fprint(stdout, taskEditPrefix, "No changes were applied.")
+		taskEditNoneColor.Fprint(stdout, taskEditPrefix, taskEditNoChange)
 		fmt.Fprintln(&sb)
 	} else {
 		t.Fprintln(stdout)

--- a/internal/console/prompt.go
+++ b/internal/console/prompt.go
@@ -104,7 +104,7 @@ func PromptAFKResolution(alert dinkur.AlertFormerlyAFK) (AFKResolution, error) {
 		promptWarnIconColor.Fprint(&sb, promptWarnIconText)
 		sb.WriteString(` Assuming option "1. Leave the active task as-is and continue with the invoked command."`)
 		fmt.Fprintln(stderr, sb.String())
-		taskEditNoneColor.Fprint(stdout, taskEditPrefix, taskEditNoChange)
+		taskEditNoneColor.Fprintln(stdout, taskEditPrefix, taskEditNoChange)
 		return AFKResolution{}, nil
 	}
 
@@ -138,7 +138,7 @@ func PromptAFKResolution(alert dinkur.AlertFormerlyAFK) (AFKResolution, error) {
 	switch answerInt {
 	case 1:
 		// Leave the active task as-is.
-		taskEditNoneColor.Fprint(stdout, taskEditPrefix, taskEditNoChange)
+		taskEditNoneColor.Fprintln(stdout, taskEditPrefix, taskEditNoChange)
 		return AFKResolution{}, nil
 
 	case 2:

--- a/internal/console/prompt.go
+++ b/internal/console/prompt.go
@@ -74,8 +74,8 @@ func PromptTaskRemoval(task dinkur.Task) error {
 // AFKResolution states what should be changed as decided from the human's AFK
 // resolution.
 type AFKResolution struct {
-	Edit     *dinkur.EditTask
-	NewTasks []dinkur.NewTask
+	Edit    *dinkur.EditTask
+	NewTask *dinkur.NewTask
 }
 
 // PromptAFKResolution asks the user for how to resolve an AFK alert.
@@ -110,15 +110,15 @@ func PromptAFKResolution(alert dinkur.AlertFormerlyAFK) (AFKResolution, error) {
 
 	sb.WriteString("How do you want to save this away time?\n")
 
-	sb.WriteString(" 1. Leave the active task as-is and continue with the invoked command.\n")
+	sb.WriteString("  1. Leave the active task as-is and continue with the invoked command.\n")
 
-	sb.WriteString(" 2. Discard the away time I was away, changing active task to ")
+	sb.WriteString("  2. Discard the away time I was away, changing active task to ")
 	writeTaskTimeSpanNowDuration(&sb, alert.ActiveTask.Start, &alert.AFKSince, alert.AFKSince.Sub(alert.ActiveTask.Start))
 	sb.WriteString(".\n")
 
-	sb.WriteString(" 3. Save the away time as a new task ")
+	sb.WriteString("  3. Save the away time as a new task ")
 	writeTaskTimeSpanNowDuration(&sb, alert.AFKSince, nil, now.Sub(alert.AFKSince))
-	sb.WriteString(" (naming it in a later prompt).\n")
+	sb.WriteString("  (naming it in a later prompt).\n")
 
 	sb.WriteByte(' ')
 	promptCtrlCHelpColor.Fprint(&sb, "(press Ctrl+C to abort)")
@@ -177,12 +177,10 @@ func promptAFKSaveAsNewTask(alert dinkur.AlertFormerlyAFK) (AFKResolution, error
 			IDOrZero: alert.ActiveTask.ID,
 			End:      &alert.AFKSince,
 		},
-		NewTasks: []dinkur.NewTask{
-			{
-				Name:               name,
-				Start:              &alert.AFKSince,
-				StartAfterIDOrZero: alert.ActiveTask.ID,
-			},
+		NewTask: &dinkur.NewTask{
+			Name:               name,
+			Start:              &alert.AFKSince,
+			StartAfterIDOrZero: alert.ActiveTask.ID,
 		},
 	}, nil
 }

--- a/internal/console/prompt.go
+++ b/internal/console/prompt.go
@@ -20,17 +20,34 @@
 package console
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/dinkur/dinkur/pkg/dinkur"
+	"github.com/mattn/go-isatty"
 )
+
+func checkIfNonInteractiveTTY() bool {
+	return os.Getenv("TERM") == "dumb" ||
+		(!isatty.IsTerminal(os.Stdout.Fd()) && !isatty.IsCygwinTerminal(os.Stdout.Fd()))
+}
+
+func convPromptErr(err error) error {
+	if err == io.EOF {
+		return fmt.Errorf("%w (maybe you are piping STDIN?)", err)
+	}
+	return err
+}
 
 // PromptTaskRemoval asks the user for confirmation about removing a task.
 // Will return an io.EOF error if the current TTY is not an interactive session.
-func PromptTaskRemoval(task dinkur.Task) (bool, error) {
+func PromptTaskRemoval(task dinkur.Task) error {
 	var sb strings.Builder
 	promptWarnIconColor.Fprint(&sb, promptWarnIconText)
 	sb.WriteByte(' ')
@@ -45,10 +62,166 @@ func PromptTaskRemoval(task dinkur.Task) (bool, error) {
 		Message: "Are you sure?",
 	}
 	if err := survey.AskOne(prompt, &ok); err != nil {
-		if err == io.EOF {
-			return false, fmt.Errorf("%w (maybe you are piping STDIN?)", err)
-		}
-		return false, err
+		return convPromptErr(err)
 	}
-	return ok, nil
+	if !ok {
+		fmt.Println("Aborted by user.")
+		os.Exit(1)
+	}
+	return nil
+}
+
+// AFKResolution states what should be changed as decided from the human's AFK
+// resolution.
+type AFKResolution struct {
+	Edit     *dinkur.EditTask
+	NewTasks []dinkur.NewTask
+}
+
+// PromptAFKResolution asks the user for how to resolve an AFK alert.
+func PromptAFKResolution(alert dinkur.AlertFormerlyAFK) (AFKResolution, error) {
+	var sb strings.Builder
+	now := time.Now()
+
+	promptWarnIconColor.Fprint(&sb, promptWarnIconText)
+	sb.WriteString(" Note: You were away since ")
+	writeTaskTimeSpanNow(&sb, alert.AFKSince, nil)
+	sb.WriteByte(' ')
+	writeTaskDurationWithDelim(&sb, now.Sub(alert.AFKSince))
+	sb.WriteByte('\n')
+	promptWarnIconColor.Fprint(&sb, promptWarnIconText)
+	sb.WriteString(" while having an active task ")
+	writeTaskID(&sb, alert.ActiveTask.ID)
+	sb.WriteByte(' ')
+	writeTaskName(&sb, alert.ActiveTask.Name)
+	sb.WriteByte(' ')
+	writeTaskTimeSpanActiveDuration(&sb, alert.ActiveTask.Start, alert.ActiveTask.End, alert.ActiveTask.Elapsed())
+	sb.WriteString("\n\n")
+
+	if checkIfNonInteractiveTTY() {
+		promptWarnIconColor.Fprint(&sb, promptWarnIconText)
+		sb.WriteString(" The terminal seems to be non-interactive.\n")
+		promptWarnIconColor.Fprint(&sb, promptWarnIconText)
+		sb.WriteString(` Assuming option "1. Leave the active task as-is and continue with the invoked command."`)
+		fmt.Fprintln(stderr, sb.String())
+		return AFKResolution{}, nil
+	}
+
+	sb.WriteString("How do you want to save this away time?\n")
+
+	sb.WriteString(" 1. Leave the active task as-is and continue with the invoked command.\n")
+
+	sb.WriteString(" 2. Discard the time I was away, changing active task to ")
+	writeTaskTimeSpanNowDuration(&sb, alert.ActiveTask.Start, &now, now.Sub(alert.ActiveTask.Start))
+	sb.WriteString(".\n")
+
+	sb.WriteString(" 3. Save the time as a new task ")
+	writeTaskTimeSpanNowDuration(&sb, alert.AFKSince, nil, now.Sub(alert.AFKSince))
+	sb.WriteString(" (naming it in a later prompt).\n")
+
+	sb.WriteString(" 4. Split the time up into multiple tasks (interactively in later prompts).\n")
+	sb.WriteByte('\n')
+
+	fmt.Fprint(stderr, sb.String())
+
+	prompt := &survey.Input{
+		Message: "Select option [1-4]:",
+	}
+	answerInt, err := promptIntRange(prompt, 1, 4)
+	if err != nil {
+		return AFKResolution{}, err
+	}
+
+	switch answerInt {
+	case 1:
+		// Leave the active task as-is.
+		fmt.Fprintln(stderr, "Leaving the active task as-is.")
+		return AFKResolution{}, nil
+
+	case 2:
+		// Discard the time
+		fmt.Fprintln(stderr, "Discarding the away time from the currently active task.")
+		return AFKResolution{
+			Edit: &dinkur.EditTask{
+				IDOrZero: alert.ActiveTask.ID,
+				End:      &alert.AFKSince,
+			},
+		}, nil
+
+	case 3:
+		// Save the time as a new task
+		name, err := promptNonEmptyString(&survey.Input{
+			Message: "Enter name of new task:",
+		})
+		if err != nil {
+			return AFKResolution{}, err
+		}
+		sb.Reset()
+		sb.WriteString("Saving the away time as a new task with name ")
+		writeTaskName(&sb, name)
+		sb.WriteString(".\n")
+		fmt.Fprint(stderr, sb.String())
+		return AFKResolution{
+			Edit: &dinkur.EditTask{
+				IDOrZero: alert.ActiveTask.ID,
+				End:      &alert.AFKSince,
+			},
+			NewTasks: []dinkur.NewTask{
+				{
+					Name:               name,
+					Start:              &alert.AFKSince,
+					StartAfterIDOrZero: alert.ActiveTask.ID,
+				},
+			},
+		}, nil
+
+	case 4:
+		// Split the time up into multiple tasks
+		return AFKResolution{}, nil // TODO:
+
+	default:
+		return AFKResolution{}, errors.New("no answer chosen")
+	}
+}
+
+func promptNonEmptyString(prompt survey.Prompt) (string, error) {
+	for {
+		var answer string
+		if err := survey.AskOne(prompt, &answer); err != nil {
+			return "", convPromptErr(err)
+		}
+
+		if answer == "" {
+			promptErrorColor.Fprintf(stderr, "Please enter a value.\n\n")
+			continue
+		}
+
+		return answer, nil
+	}
+}
+
+func promptIntRange(prompt survey.Prompt, lower, upper int) (int, error) {
+	for {
+		answer, err := promptNonEmptyString(prompt)
+		if err != nil {
+			return 0, err
+		}
+
+		answerInt, err := strconv.Atoi(answer)
+		if err != nil {
+			promptErrorColor.Fprintf(stderr, "Invalid answer: %v\n\n", err)
+			continue
+		}
+
+		if answerInt < lower || answerInt > upper {
+			promptErrorColor.Fprintf(stderr, "Please enter a value in the range %d-%d.\n\n", lower, upper)
+			continue
+		}
+
+		return answerInt, nil
+	}
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
 }

--- a/internal/console/writetableutil.go
+++ b/internal/console/writetableutil.go
@@ -41,20 +41,20 @@ func writeCellsLabelledTask(t *table, labelled LabelledTask) {
 
 func writeCellTaskID(t *table, id uint) {
 	var sb strings.Builder
-	w := writeTaskID(&sb, id)
-	t.WriteCellWidth(sb.String(), w)
+	width := writeTaskID(&sb, id)
+	t.WriteCellWidth(sb.String(), width)
 }
 
 func writeCellTaskName(t *table, name string) {
 	var sb strings.Builder
-	w := writeTaskName(&sb, name)
-	t.WriteCellWidth(sb.String(), w)
+	width := writeTaskName(&sb, name)
+	t.WriteCellWidth(sb.String(), width)
 }
 
 func writeCellTaskNameSearched(t *table, name string, reg *regexp.Regexp) {
 	var sb strings.Builder
-	w := writeTaskNameSearched(&sb, name, reg)
-	t.WriteCellWidth(sb.String(), w)
+	width := writeTaskNameSearched(&sb, name, reg)
+	t.WriteCellWidth(sb.String(), width)
 }
 
 func writeCellDate(t *table, d date) {
@@ -64,23 +64,20 @@ func writeCellDate(t *table, d date) {
 
 func writeCellTimeColor(t *table, ti time.Time, layout string, c *color.Color) {
 	var sb strings.Builder
-	w := writeTimeColor(&sb, ti, layout, c)
-	t.WriteCellWidth(sb.String(), w)
+	width := writeTimeColor(&sb, ti, layout, c)
+	t.WriteCellWidth(sb.String(), width)
 }
 
 func writeCellTaskTimeSpan(t *table, start time.Time, end *time.Time) {
 	var sb strings.Builder
-	visualLen := writeTaskTimeSpan(&sb, start, end)
-	t.WriteCellWidth(sb.String(), visualLen)
+	width := writeTaskTimeSpanActive(&sb, start, end)
+	t.WriteCellWidth(sb.String(), width)
 }
 
 func writeCellTaskTimeSpanDuration(t *table, start time.Time, end *time.Time, dur time.Duration) {
 	var sb strings.Builder
-	w := writeTaskTimeSpan(&sb, start, end)
-	sb.WriteByte(' ')
-	w++
-	w += writeTaskDurationWithDelim(&sb, dur)
-	t.WriteCellWidth(sb.String(), w)
+	width := writeTaskTimeSpanActiveDuration(&sb, start, end, dur)
+	t.WriteCellWidth(sb.String(), width)
 }
 
 func writeCellTaskStartEnd(t *table, start time.Time, end *time.Time) {
@@ -92,12 +89,12 @@ func writeCellTaskStartEnd(t *table, start time.Time, end *time.Time) {
 		}
 		writeCellTimeColor(t, *end, endLayout, taskEndColor)
 	} else {
-		t.WriteCellColor(taskEndNilText, taskEndNilColor)
+		t.WriteCellColor(taskEndNilTextActive, taskEndNilColor)
 	}
 }
 
 func writeCellDuration(t *table, d time.Duration) {
 	var sb strings.Builder
-	w := writeTaskDuration(&sb, d)
-	t.WriteCellWidth(sb.String(), w)
+	width := writeTaskDuration(&sb, d)
+	t.WriteCellWidth(sb.String(), width)
 }

--- a/pkg/dinkuralert/dinkuralert.go
+++ b/pkg/dinkuralert/dinkuralert.go
@@ -41,7 +41,12 @@ type Store struct {
 // Alerts returns a slice of all alerts.
 func (s *Store) Alerts() []dinkur.Alert {
 	var alerts []dinkur.Alert
-	// TODO
+	if s.afkAlert != nil {
+		alerts = append(alerts, *s.afkAlert)
+	}
+	if s.formerlyAFKAlert != nil {
+		alerts = append(alerts, *s.formerlyAFKAlert)
+	}
 	return alerts
 }
 

--- a/pkg/dinkuralert/dinkuralert.go
+++ b/pkg/dinkuralert/dinkuralert.go
@@ -57,15 +57,17 @@ func (s *Store) Delete(id uint) (dinkur.Alert, error) {
 			Alert: *s.afkAlert,
 			Event: dinkur.EventDeleted,
 		})
+		alert := *s.afkAlert
 		s.afkAlert = nil
-		return *s.afkAlert, nil
+		return alert, nil
 	} else if s.formerlyAFKAlert != nil && s.formerlyAFKAlert.ID == id {
 		s.PubAlertWait(AlertEvent{
 			Alert: *s.formerlyAFKAlert,
 			Event: dinkur.EventDeleted,
 		})
+		alert := *s.formerlyAFKAlert
 		s.formerlyAFKAlert = nil
-		return *s.formerlyAFKAlert, nil
+		return alert, nil
 	}
 	return dinkur.Alert{}, dinkur.ErrNotFound
 }

--- a/pkg/dinkuralert/dinkuralert.go
+++ b/pkg/dinkuralert/dinkuralert.go
@@ -51,21 +51,23 @@ func (s *Store) Alerts() []dinkur.Alert {
 }
 
 // Delete removes an alert by ID.
-func (s *Store) Delete(id uint) error {
+func (s *Store) Delete(id uint) (dinkur.Alert, error) {
 	if s.afkAlert != nil && s.afkAlert.ID == id {
 		s.PubAlertWait(AlertEvent{
 			Alert: *s.afkAlert,
 			Event: dinkur.EventDeleted,
 		})
 		s.afkAlert = nil
+		return *s.afkAlert, nil
 	} else if s.formerlyAFKAlert != nil && s.formerlyAFKAlert.ID == id {
 		s.PubAlertWait(AlertEvent{
 			Alert: *s.formerlyAFKAlert,
 			Event: dinkur.EventDeleted,
 		})
 		s.formerlyAFKAlert = nil
+		return *s.formerlyAFKAlert, nil
 	}
-	return nil
+	return dinkur.Alert{}, dinkur.ErrNotFound
 }
 
 // SetAFK marks the user as AFK and creates the AFK alert if it doesn't exist,

--- a/pkg/dinkurd/alerterserver.go
+++ b/pkg/dinkurd/alerterserver.go
@@ -61,10 +61,7 @@ func (d *daemon) GetAlertList(ctx context.Context, req *dinkurapiv1.GetAlertList
 	if req == nil {
 		return nil, convError(ErrRequestIsNil)
 	}
-	alerts, err := d.client.GetAlertList(ctx)
-	if err != nil {
-		return nil, convError(err)
-	}
+	alerts := d.alertStore.Alerts()
 	return &dinkurapiv1.GetAlertListResponse{
 		Alerts: convAlertSlice(alerts),
 	}, nil
@@ -77,11 +74,11 @@ func (d *daemon) DeleteAlert(ctx context.Context, req *dinkurapiv1.DeleteAlertRe
 	if req == nil {
 		return nil, convError(ErrRequestIsNil)
 	}
-	id, err := uint64ToUint(req.Id)
+	id, err := convUint64(req.Id)
 	if err != nil {
 		return nil, convError(err)
 	}
-	deleted, err := d.client.DeleteAlert(ctx, id)
+	deleted, err := d.alertStore.Delete(id)
 	if err != nil {
 		return nil, convError(err)
 	}

--- a/pkg/dinkurd/alerterserver.go
+++ b/pkg/dinkurd/alerterserver.go
@@ -54,7 +54,7 @@ func (d *daemon) StreamAlert(req *dinkurapiv1.StreamAlertRequest, stream dinkura
 	}
 }
 
-func (d *daemon) GetAlertList(ctx context.Context, req *dinkurapiv1.GetAlertListRequest) (*dinkurapiv1.GetAlertListResponse, error) {
+func (d *daemon) GetAlertList(_ context.Context, req *dinkurapiv1.GetAlertListRequest) (*dinkurapiv1.GetAlertListResponse, error) {
 	if err := d.assertConnected(); err != nil {
 		return nil, convError(err)
 	}
@@ -67,7 +67,7 @@ func (d *daemon) GetAlertList(ctx context.Context, req *dinkurapiv1.GetAlertList
 	}, nil
 }
 
-func (d *daemon) DeleteAlert(ctx context.Context, req *dinkurapiv1.DeleteAlertRequest) (*dinkurapiv1.DeleteAlertResponse, error) {
+func (d *daemon) DeleteAlert(_ context.Context, req *dinkurapiv1.DeleteAlertRequest) (*dinkurapiv1.DeleteAlertResponse, error) {
 	if err := d.assertConnected(); err != nil {
 		return nil, convError(err)
 	}


### PR DESCRIPTION
Added check when connecting to gRPC API to ask the user of how to resolve it.

## Preview

After the initial `dinkur --client grpc in testing` in the screenshot below, I stepped away from the computer for almost 10 minutes and came back and ran the `dinkur --client grpc in status`. The Dinkur daemon was running in a separate terminal.

![image](https://user-images.githubusercontent.com/2477952/148566242-64b32539-1f7f-46af-bec1-ca4c9e93014a.png)

## Unrelated changes

- Added --grpc-address flag
- Changed alerterserver List and Delete methods to use alert store

---

Closes #16
