### PR TITLE
Added more `dinkur list --output` formats

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -34,6 +34,7 @@ import (
 	"github.com/dinkur/dinkur/pkg/dinkur"
 	"github.com/dinkur/dinkur/pkg/timeutil"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
@@ -112,6 +113,10 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 				for _, t := range tasks {
 					enc.Encode(t)
 				}
+			case "yaml":
+				enc := yaml.NewEncoder(os.Stdout)
+				enc.SetIndent(2)
+				enc.Encode(tasks)
 			default:
 				console.PrintFatal("Error parsing --output:", fmt.Errorf("invalid output format: %q", flagOutput))
 			}
@@ -125,7 +130,7 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 	listCmd.Flags().VarP(flagEnd, "end", "e", "list tasks ending before or at date time")
 	listCmd.Flags().VarP(flagRange, "range", "r", "baseline time range")
 	listCmd.RegisterFlagCompletionFunc("range", pflagutil.TimeRangeCompletion)
-	listCmd.Flags().StringVarP(&flagOutput, "output", "o", flagOutput, `set output format: "pretty", "json", or "json-line"`)
+	listCmd.Flags().StringVarP(&flagOutput, "output", "o", flagOutput, `set output format: "pretty", "json", "json-line", "yaml"`)
 	listCmd.RegisterFlagCompletionFunc("output", outputFormatComplete)
 	listCmd.Flags().BoolVar(&flagNoHighlight, "no-highlight", false, `disables search highlighting in "pretty" output`)
 }
@@ -135,5 +140,6 @@ func outputFormatComplete(*cobra.Command, []string, string) ([]string, cobra.She
 		"pretty\thuman readable and colored table formatting (default)",
 		"json\ta single indented JSON array containing all tasks",
 		"json-line\teach task JSON object on a separate line",
+		"yaml\tYAML array of tasks",
 	}, cobra.ShellCompDirectiveDefault
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -107,7 +107,7 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
 				enc.Encode(tasks)
-			case "jsonl":
+			case "json-line":
 				enc := json.NewEncoder(os.Stdout)
 				for _, t := range tasks {
 					enc.Encode(t)
@@ -125,7 +125,7 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 	listCmd.Flags().VarP(flagEnd, "end", "e", "list tasks ending before or at date time")
 	listCmd.Flags().VarP(flagRange, "range", "r", "baseline time range")
 	listCmd.RegisterFlagCompletionFunc("range", pflagutil.TimeRangeCompletion)
-	listCmd.Flags().StringVarP(&flagOutput, "output", "o", flagOutput, `set output format: "pretty", "json", or "jsonl"`)
+	listCmd.Flags().StringVarP(&flagOutput, "output", "o", flagOutput, `set output format: "pretty", "json", or "json-line"`)
 	listCmd.RegisterFlagCompletionFunc("output", outputFormatComplete)
 	listCmd.Flags().BoolVar(&flagNoHighlight, "no-highlight", false, `disables search highlighting in "pretty" output`)
 }
@@ -134,6 +134,6 @@ func outputFormatComplete(*cobra.Command, []string, string) ([]string, cobra.She
 	return []string{
 		"pretty\thuman readable and colored table formatting (default)",
 		"json\ta single indented JSON array containing all tasks",
-		"jsonl\teach task JSON object on a separate line",
+		"json-line\teach task JSON object on a separate line",
 	}, cobra.ShellCompDirectiveDefault
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"math/rand"
 	"os"
@@ -123,6 +124,22 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 				if err := enc.Encode(tasks); err != nil {
 					console.PrintFatal("Error encoding tasks as YAML:", err)
 				}
+			case "xml":
+				enc := xml.NewEncoder(os.Stdout)
+				enc.Indent("", "    ")
+				if err := enc.Encode(tasks); err != nil {
+					console.PrintFatal("Error encoding tasks as XML:", err)
+				}
+				fmt.Println()
+			case "xml-line":
+				enc := xml.NewEncoder(os.Stdout)
+				for _, t := range tasks {
+					if err := enc.Encode(t); err != nil {
+						fmt.Println()
+						console.PrintFatal(fmt.Sprintf("Error encoding task #%d as XML:", t.ID), err)
+					}
+					fmt.Println()
+				}
 			default:
 				console.PrintFatal("Error parsing --output:", fmt.Errorf("invalid output format: %q", flagOutput))
 			}
@@ -136,7 +153,7 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 	listCmd.Flags().VarP(flagEnd, "end", "e", "list tasks ending before or at date time")
 	listCmd.Flags().VarP(flagRange, "range", "r", "baseline time range")
 	listCmd.RegisterFlagCompletionFunc("range", pflagutil.TimeRangeCompletion)
-	listCmd.Flags().StringVarP(&flagOutput, "output", "o", flagOutput, `set output format: "pretty", "json", "json-line", "yaml"`)
+	listCmd.Flags().StringVarP(&flagOutput, "output", "o", flagOutput, `set output format: "pretty", "json", "json-line", "yaml", "xml", "xml-line"`)
 	listCmd.RegisterFlagCompletionFunc("output", outputFormatComplete)
 	listCmd.Flags().BoolVar(&flagNoHighlight, "no-highlight", false, `disables search highlighting in "pretty" output`)
 }
@@ -147,5 +164,7 @@ func outputFormatComplete(*cobra.Command, []string, string) ([]string, cobra.She
 		"json\ta single indented JSON array containing all tasks",
 		"json-line\teach task JSON object on a separate line",
 		"yaml\tYAML array of tasks",
+		"xml\tXML list of tasks",
+		"xml-line\teach task XML element on a separate line",
 	}, cobra.ShellCompDirectiveDefault
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -107,16 +107,22 @@ Week baselines sets the range Monday 00:00:00 - Sunday 24:59:59.
 			case "json":
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
-				enc.Encode(tasks)
+				if err := enc.Encode(tasks); err != nil {
+					console.PrintFatal("Error encoding tasks as JSON:", err)
+				}
 			case "json-line":
 				enc := json.NewEncoder(os.Stdout)
 				for _, t := range tasks {
-					enc.Encode(t)
+					if err := enc.Encode(t); err != nil {
+						console.PrintFatal(fmt.Sprintf("Error encoding task #%d as JSON:", t.ID), err)
+					}
 				}
 			case "yaml":
 				enc := yaml.NewEncoder(os.Stdout)
 				enc.SetIndent(2)
-				enc.Encode(tasks)
+				if err := enc.Encode(tasks); err != nil {
+					console.PrintFatal("Error encoding tasks as YAML:", err)
+				}
 			default:
 				console.PrintFatal("Error parsing --output:", fmt.Errorf("invalid output format: %q", flagOutput))
 			}

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,14 @@ require (
 	github.com/godbus/dbus/v5 v5.0.6
 	github.com/iver-wharf/wharf-core v1.3.0
 	github.com/mattn/go-colorable v0.1.12
+	github.com/mattn/go-isatty v0.0.14
 	github.com/mattn/go-sqlite3 v1.14.10
 	github.com/olebedev/when v0.0.0-20211212231525-59bd4edcf9d6
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
 	google.golang.org/grpc v1.43.0
 	google.golang.org/protobuf v1.27.1
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gorm.io/driver/sqlite v1.2.6
 	gorm.io/gorm v1.22.4
 )
@@ -35,7 +37,6 @@ require (
 	github.com/jinzhu/now v1.1.4 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
-	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect

--- a/pkg/dinkur/models.go
+++ b/pkg/dinkur/models.go
@@ -25,22 +25,22 @@ import "time"
 type CommonFields struct {
 	// ID is a unique identifier for this task. The same ID will never be used
 	// twice for a given database.
-	ID uint `json:"id"`
+	ID uint `json:"id" yaml:"id"`
 	// CreatedAt is when the object was created.
-	CreatedAt time.Time `json:"createdAt"`
+	CreatedAt time.Time `json:"createdAt" yaml:"createdAt"`
 	// UpdatedAt stores when the object was last updated/edited.
-	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedAt time.Time `json:"updatedAt" yaml:"updatedAt"`
 }
 
 // Task is a time tracked task.
 type Task struct {
-	CommonFields
+	CommonFields `yaml:",inline"`
 	// Name of the task.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// Start time of the task.
-	Start time.Time `json:"start"`
+	Start time.Time `json:"start" yaml:"start"`
 	// End time of the task, or nil if the task is still active.
-	End *time.Time `json:"end"`
+	End *time.Time `json:"end" yaml:"end"`
 }
 
 // Elapsed returns the duration of the task. If the task is currently active,

--- a/pkg/dinkur/models.go
+++ b/pkg/dinkur/models.go
@@ -25,22 +25,22 @@ import "time"
 type CommonFields struct {
 	// ID is a unique identifier for this task. The same ID will never be used
 	// twice for a given database.
-	ID uint `json:"id" yaml:"id"`
+	ID uint `json:"id" yaml:"id" xml:"Id"`
 	// CreatedAt is when the object was created.
-	CreatedAt time.Time `json:"createdAt" yaml:"createdAt"`
+	CreatedAt time.Time `json:"createdAt" yaml:"createdAt" xml:"CreatedAt"`
 	// UpdatedAt stores when the object was last updated/edited.
-	UpdatedAt time.Time `json:"updatedAt" yaml:"updatedAt"`
+	UpdatedAt time.Time `json:"updatedAt" yaml:"updatedAt" xml:"UpdatedAt"`
 }
 
 // Task is a time tracked task.
 type Task struct {
 	CommonFields `yaml:",inline"`
 	// Name of the task.
-	Name string `json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name" xml:"Name"`
 	// Start time of the task.
-	Start time.Time `json:"start" yaml:"start"`
+	Start time.Time `json:"start" yaml:"start" xml:"Start"`
 	// End time of the task, or nil if the task is still active.
-	End *time.Time `json:"end" yaml:"end"`
+	End *time.Time `json:"end" yaml:"end" xml:"End"`
 }
 
 // Elapsed returns the duration of the task. If the task is currently active,


### PR DESCRIPTION
- Renamed `--output jsonl` to `--output json-line`
- Added `--output=yaml`
- Added `--output=xml` and `--output=xml-line`
- Added `--output=csv` and `--output=csv-header`

The issue #34 also suggests `toml`, `csv-semicolon`, and `csv-tab`, but I did not implement them as I did not want to introduce any new packages for TOML and the Go package `encoding/csv` did not changing to other delimiters.

---

Closes #34
