### PR TITLE
bugfix/inconsistent time parsing

### DIFF
--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -141,19 +141,8 @@ func PrintEntryEdit(update dinkur.UpdatedEntry) {
 		writeCellEntryName(&t, update.After.Name)
 		t.CommitRow()
 	}
-	var (
-		oldStartUnix = update.Before.Start.UnixMilli()
-		oldEndUnix   int64
-		newStartUnix = update.After.Start.UnixMilli()
-		newEndUnix   int64
-	)
-	if update.Before.End != nil {
-		oldEndUnix = update.Before.End.Unix()
-	}
-	if update.After.End != nil {
-		newEndUnix = update.After.End.Unix()
-	}
-	if oldStartUnix != newStartUnix || oldEndUnix != newEndUnix {
+	if !timesEqual(update.Before.Start, update.After.Start) ||
+		!timesPtrsEqual(update.Before.End, update.After.End) {
 		writeCellEntryTimeSpanDuration(&t, update.Before.Start, update.Before.End, update.Before.Elapsed())
 		t.WriteCellColor(entryEditDelim, entryEditDelimColor)
 		writeCellEntryTimeSpanDuration(&t, update.After.Start, update.After.End, update.After.Elapsed())

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -160,8 +160,7 @@ func PrintEntryEdit(update dinkur.UpdatedEntry) {
 		t.CommitRow()
 	}
 	if t.Rows() == 0 {
-		entryEditNoneColor.Fprint(stdout, entryEditPrefix, entryEditNoChange)
-		fmt.Fprintln(&sb)
+		entryEditNoneColor.Fprintln(stdout, entryEditPrefix, entryEditNoChange)
 	} else {
 		t.Fprintln(stdout)
 	}

--- a/internal/console/util.go
+++ b/internal/console/util.go
@@ -151,3 +151,17 @@ func uintWidth(i uint) int {
 		return 20
 	}
 }
+
+func timesEqual(a, b time.Time) bool {
+	return a.UnixMilli() == b.UnixMilli()
+}
+
+func timesPtrsEqual(a, b *time.Time) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return timesEqual(*a, *b)
+}

--- a/internal/fuzzytime/fuzzytime.go
+++ b/internal/fuzzytime/fuzzytime.go
@@ -85,7 +85,7 @@ func ParseKnownLayouts(s string) (time.Time, error) {
 
 // ParseWhen performs a fuzzy time parsing via the `when` package.
 func ParseWhen(s string) (time.Time, error) {
-	r, err := w.Parse(s, time.Now())
+	r, err := w.Parse(s, time.Now().Truncate(time.Second))
 	if err != nil {
 		return time.Time{}, err
 	}


### PR DESCRIPTION
- Fixed missing newline
- Fixed time equality comparison
- Truncated fuzzy time to seconds

The big bug fix was actually in https://github.com/dinkur/dinkur/pull/58/commits/522580fe399d86a436387d6e776cea0892109206

The `when` parser for hour:minute (and many other rules) doesn't set the time's nanoseconds (https://github.com/olebedev/when/blob/59bd4edcf9d671b3c73416c7b0d55356444507d4/rules/en/hour_minute.go), but instead leaves that as default.

So the nanosecond used was the one from the base value, i.e. `time.Now`.

Truncating the base value means that if the user specifies the nanoseconds, then it will apply, but if not then 0 is used instead.

Closes #57
